### PR TITLE
Cache the redhat-logos package

### DIFF
--- a/templates/base_pkgs.erb
+++ b/templates/base_pkgs.erb
@@ -168,6 +168,7 @@ python-crypto
 pycairo
 pyOpenSSL
 recode
+redhat-logos
 rhino
 ruby
 ruby-irb


### PR DESCRIPTION
This will allow apache to be installed on container nodes.

Side note: holy shit, does this list need to be audited or what?
