### PR TITLE
Added basic rspec testing

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,10 @@
+fixtures:
+  symlinks:
+    localrepo: "#{source_dir}"
+  forge_modules:
+    stdlib:
+      repo: "puppetlabs/stdlib"
+      ref: "4.12.0"
+    epel:
+      repo: "stahnma/epel"
+      ref: "1.2.2"

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,1 @@
+require 'puppetlabs_spec_helper/rake_tasks'

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe "localrepo" do
+  let(:node) { 'test.example.com' }
+
+  let(:facts) { {
+    :osfamily                  => 'RedHat',
+    :operatingsystem           => 'CentOS',
+    :operatingsystemmajrelease => '7',
+    :architecture              => 'x86_64',
+  } }
+
+  let(:pre_condition) do
+    <<-EOF
+      include 'epel'
+    EOF
+  end
+
+  it { is_expected.to compile.with_all_deps }
+end

--- a/spec/classes/packages_spec.rb
+++ b/spec/classes/packages_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe "localrepo::packages" do
+  let(:node) { 'test.example.com' }
+
+  let(:facts) { {
+    :osfamily                  => 'RedHat',
+    :operatingsystem           => 'CentOS',
+    :operatingsystemmajrelease => '7',
+    :architecture              => 'x86_64',
+  } }
+
+  it { is_expected.to compile.with_all_deps }
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,1 @@
+require 'puppetlabs_spec_helper/module_spec_helper'


### PR DESCRIPTION
TRAINTECH-717 #ready for review #time 30m

Puppet-Pirate:~/pltraining/pltraining-localrepo/spec joaks (TRAINTECH-717)$ rake spec
(in /Users/joaks/pltraining/pltraining-localrepo)
Notice: Preparing to install into /Users/joaks/pltraining/pltraining-localrepo/spec/fixtures/modules ...
Notice: Downloading from https://forgeapi.puppetlabs.com ...
Notice: Installing -- do not interrupt ...
/Users/joaks/pltraining/pltraining-localrepo/spec/fixtures/modules
└── puppetlabs-stdlib (v4.12.0)
Notice: Preparing to install into /Users/joaks/pltraining/pltraining-localrepo/spec/fixtures/modules ...
Notice: Downloading from https://forgeapi.puppetlabs.com ...
Notice: Installing -- do not interrupt ...
/Users/joaks/pltraining/pltraining-localrepo/spec/fixtures/modules
└── stahnma-epel (v1.2.2)
/usr/local/Cellar/ruby/2.3.1_2/bin/ruby -I/usr/local/lib/ruby/gems/2.3.0/gems/rspec-support-3.5.0/lib:/usr/local/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib /usr/local/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/exe/rspec --pattern spec/\{aliases,classes,defines,unit,functions,hosts,integration,types\}/\*\*/\*_spec.rb --color
..

Finished in 3.05 seconds (files took 1.03 seconds to load)
2 examples, 0 failures